### PR TITLE
Fixing bugs where tiles are drawn in the wrong place.

### DIFF
--- a/leaflet-image.js
+++ b/leaflet-image.js
@@ -86,8 +86,12 @@ module.exports = function leafletImage(map, callback) {
         tileQueue.awaitAll(tileQueueFinish);
 
         function loadTile(tilePoint, callback) {
+            //originalTilePoint is used to handle repeated tiles wrap the world.
+            var originalTilePoint = tilePoint.clone();
             layer._adjustTilePoint(tilePoint);
-            var tilePos = layer._getTilePos(tilePoint).subtract(offset);
+            var tilePos = layer._getTilePos(originalTilePoint)
+                .subtract(bounds.min)
+                .add(origin);
             var url = layer.getTileUrl(tilePoint) + '?cache=' + (+new Date());
             var im = new Image();
             im.crossOrigin = '';


### PR DESCRIPTION
The simplest way to reproduce one of the bugs this fixes is to zoom out until you see most of the world in the demo page then generate an image.
