### PR TITLE
use the same timestamp for loading resources within one leafletImage call

### DIFF
--- a/leaflet-image.js
+++ b/leaflet-image.js
@@ -5,7 +5,8 @@ var queue = _dereq_('./queue');
 module.exports = function leafletImage(map, callback) {
 
     var dimensions = map.getSize(),
-        layerQueue = new queue(1);
+        layerQueue = new queue(1),
+        ts = new Date();
 
     var canvas = document.createElement('canvas');
     canvas.width = dimensions.x;
@@ -167,7 +168,7 @@ module.exports = function leafletImage(map, callback) {
     }
 
     function addCacheString(url) {
-        return url + ((url.match(/\?/)) ? '&' : '?') + 'cache=' + (+new Date());
+        return url + ((url.match(/\?/)) ? '&' : '?') + 'cache=' + (+ts);
     }
 };
 


### PR DESCRIPTION
I've got a map where some icons appear 100 times. The change avoids loading the same resource again and again, i.e. icon.png?cache=1, icon.png?cache=2, icon.png?cache=3 and so on...
As a result this change speeds up processing. Moreover it avoids caching issues because each time leafletImage() is called, a new timestamp is used.
