### PR TITLE
Update old version referenced in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ leafletImage(map, function(err, canvas) {
 leaflet-image is [available through the Mapbox Plugin CDN](https://www.mapbox.com/mapbox.js/plugins/#leaflet-image) so you don't need to download & copy it. Just include the following script tag:
 
 ```html
-<script src='//api.tiles.mapbox.com/mapbox.js/plugins/leaflet-image/v0.0.3/leaflet-image.js'></script>
+<script src='//api.tiles.mapbox.com/mapbox.js/plugins/leaflet-image/v0.0.4/leaflet-image.js'></script>
 ```
 
 ### API


### PR DESCRIPTION
I ran into an issue where I copied the code from the readme which referenced version `0.0.3` which had a bug in it.
