### PR TITLE
Fix to the issue when imageOverlay is not rasterized when other elements are included in the map.

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,11 +23,14 @@ module.exports = function leafletImage(map, callback) {
     // layers are drawn in the same order as they are composed in the DOM:
     // tiles, paths, and then markers
     map.eachLayer(drawTileLayer);
-    if (map._pathRoot) {
-        layerQueue.defer(handlePathRoot, map._pathRoot);
-    } else if (map._panes && map._panes.overlayPane.firstChild) {
-        layerQueue.defer(handlePathRoot, map._panes.overlayPane.firstChild);
+
+    // If overlayPane has childNodes, it will iterates over all of them
+    if (map._panes && map._panes.overlayPane.childNodes){
+        for(var i = 0; i < map._panes.overlayPane.childNodes.length; i++){
+            layerQueue.defer(handlePathRoot, map._panes.overlayPane.childNodes[i]);
+        }
     }
+
     map.eachLayer(drawMarkerLayer);
     layerQueue.awaitAll(layersDone);
 
@@ -172,7 +175,7 @@ module.exports = function leafletImage(map, callback) {
         canvas.height = dimensions.y;
         var ctx = canvas.getContext('2d');
         var pos = L.DomUtil.getPosition(root).subtract(bounds.min).add(origin);
-        ctx.drawImage(root, pos.x, pos.y);
+        ctx.drawImage(root, pos.x, pos.y, root.width, root.height);
         callback(null, {
             canvas: canvas
         });

--- a/leaflet-image.js
+++ b/leaflet-image.js
@@ -25,11 +25,14 @@ module.exports = function leafletImage(map, callback) {
     // layers are drawn in the same order as they are composed in the DOM:
     // tiles, paths, and then markers
     map.eachLayer(drawTileLayer);
-    if (map._pathRoot) {
-        layerQueue.defer(handlePathRoot, map._pathRoot);
-    } else if (map._panes && map._panes.overlayPane.firstChild) {
-        layerQueue.defer(handlePathRoot, map._panes.overlayPane.firstChild);
+
+    // If overlayPane has childNodes, it will iterates over all of them
+    if (map._panes && map._panes.overlayPane.childNodes){
+        for(var i = 0; i < map._panes.overlayPane.childNodes.length; i++){
+            layerQueue.defer(handlePathRoot, map._panes.overlayPane.childNodes[i]);
+        }
     }
+
     map.eachLayer(drawMarkerLayer);
     layerQueue.awaitAll(layersDone);
 
@@ -174,7 +177,7 @@ module.exports = function leafletImage(map, callback) {
         canvas.height = dimensions.y;
         var ctx = canvas.getContext('2d');
         var pos = L.DomUtil.getPosition(root).subtract(bounds.min).add(origin);
-        ctx.drawImage(root, pos.x, pos.y);
+        ctx.drawImage(root, pos.x, pos.y, root.width, root.height);
         callback(null, {
             canvas: canvas
         });


### PR DESCRIPTION
Issue: When there's an imageOverlay in the map and the map also has any other elements like polygons, circles, markers or even another imageOverlay, the images are deliberately ignored when forming the canvas.

Cause: When there's and imageOverlay in the map along with other elements, the map._panes.ovelayPane has as children more than one element, the canvas with all the elements and each imageOverlay included as independent child (IMG) of the overlayPane. The current code is only getting the map._pathRoot that is the canvas with all the elements, and this canvas does not include images, when map._pathRoot is not defined, the code only gets the first child of the overlayPan, ignoring any image or element added as child of it after the first element.

Fix: Changed if/else block with a for loop through all children of overlayPane to be drawn in the main canvas, there's no need to manage the difference between map._pathRoot and map._panes.overlayPane, because always the same element of the _pathRoot (a canvas) is included as a child of the map._panes.ovelayPane, also added the parameters root.width and root.height to the ctx.drawImage to preserve the displayed size of the element and not the original size of the file in case of an image.
