### PR TITLE
Add support for Leaflet v1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ Canvas and [CORS](http://en.wikipedia.org/wiki/Cross-origin_resource_sharing).
   don't, so they aren't supported.
 * Your browser must support [CORS](http://caniuse.com/#feat=cors) and [Canvas](http://caniuse.com/#feat=canvas),
   so `IE >= 10` with no exceptions.
-* You must set `L_PREFER_CANVAS = true;` so that vector layers are drawn in Canvas
-  rather than SVG or VML.
+* __(Leaflet < 1.0.0)__ You must set `L_PREFER_CANVAS = true;` so that vector
+  layers are drawn in Canvas
+* __(Leaflet >= 1.0.0)__ You must set `renderer: L.canvas()` for any layer that
+  you want included in the generated image.
 * This library **does not rasterize HTML** because **browsers cannot rasterize HTML**. Therefore,
   L.divIcon and other HTML-based features of a map, like zoom controls or legends, are not
   included in the output, because they are HTML.

--- a/index.js
+++ b/index.js
@@ -174,7 +174,7 @@ module.exports = function leafletImage(map, callback) {
         canvas.height = dimensions.y;
         var ctx = canvas.getContext('2d');
         var pos = L.DomUtil.getPosition(root).subtract(bounds.min).add(origin);
-        ctx.drawImage(root, pos.x, pos.y);
+        ctx.drawImage(root, pos.x, pos.y, canvas.width - (pos.x * 2), canvas.height - (pos.y * 2));
         callback(null, {
             canvas: canvas
         });

--- a/index.js
+++ b/index.js
@@ -25,8 +25,9 @@ module.exports = function leafletImage(map, callback) {
     map.eachLayer(drawTileLayer);
     if (map._pathRoot) {
         layerQueue.defer(handlePathRoot, map._pathRoot);
-    } else if (map._panes && map._panes.overlayPane.firstChild) {
-        layerQueue.defer(handlePathRoot, map._panes.overlayPane.firstChild);
+    } else if (map._panes) {
+      var firstCanvas = map._panes.overlayPane.getElementsByTagName('canvas').item(0);
+      if (firstCanvas) { layerQueue.defer(handlePathRoot, firstCanvas); }
     }
     map.eachLayer(drawMarkerLayer);
     layerQueue.awaitAll(layersDone);

--- a/index.js
+++ b/index.js
@@ -58,7 +58,8 @@ module.exports = function leafletImage(map, callback) {
     }
 
     function handleTileLayer(layer, callback) {
-        var isCanvasLayer = (layer instanceof L.TileLayer.Canvas),
+        // `L.TileLayer.Canvas` was removed in leaflet 1.0
+        var isCanvasLayer = (L.TileLayer.Canvas && layer instanceof L.TileLayer.Canvas),
             canvas = document.createElement('canvas');
 
         canvas.width = dimensions.x;

--- a/leaflet-image.js
+++ b/leaflet-image.js
@@ -27,8 +27,9 @@ module.exports = function leafletImage(map, callback) {
     map.eachLayer(drawTileLayer);
     if (map._pathRoot) {
         layerQueue.defer(handlePathRoot, map._pathRoot);
-    } else if (map._panes && map._panes.overlayPane.firstChild) {
-        layerQueue.defer(handlePathRoot, map._panes.overlayPane.firstChild);
+    } else if (map._panes) {
+      var firstCanvas = map._panes.overlayPane.getElementsByTagName('canvas').item(0);
+      if (firstCanvas) { layerQueue.defer(handlePathRoot, firstCanvas); }
     }
     map.eachLayer(drawMarkerLayer);
     layerQueue.awaitAll(layersDone);
@@ -59,7 +60,8 @@ module.exports = function leafletImage(map, callback) {
     }
 
     function handleTileLayer(layer, callback) {
-        var isCanvasLayer = (layer instanceof L.TileLayer.Canvas),
+        // `L.TileLayer.Canvas` was removed in leaflet 1.0
+        var isCanvasLayer = (L.TileLayer.Canvas && layer instanceof L.TileLayer.Canvas),
             canvas = document.createElement('canvas');
 
         canvas.width = dimensions.x;
@@ -174,7 +176,7 @@ module.exports = function leafletImage(map, callback) {
         canvas.height = dimensions.y;
         var ctx = canvas.getContext('2d');
         var pos = L.DomUtil.getPosition(root).subtract(bounds.min).add(origin);
-        ctx.drawImage(root, pos.x, pos.y);
+        ctx.drawImage(root, pos.x, pos.y, canvas.width - (pos.x * 2), canvas.height - (pos.y * 2));
         callback(null, {
             canvas: canvas
         });


### PR DESCRIPTION
Made a few changes to get this thing to support Leaflet 1.0.0-beta.2.
# Main Problems

Apart from minor API incompatibilities, this was happening on browsers in Retina screens:

![demo of problem](https://cloud.githubusercontent.com/assets/1542531/14401757/1182d82c-fdeb-11e5-905e-76cf010bceef.png)
# Browsers Testing

I tested in:
- Firefox 47
- Chrome 49
- IE11

The proof is below:
## Retina
### Leaflet 0.7, Chrome 49

![retina 0 7 chrome](https://cloud.githubusercontent.com/assets/1542531/14401781/ae285576-fdeb-11e5-8d7c-192121a218c4.png)
### Leaflet 0.7, Firefox 47

<img width="1649" alt="retina 0 7 firefox" src="https://cloud.githubusercontent.com/assets/1542531/14401782/b4ed10e0-fdeb-11e5-9fa6-e06b4d8a2008.png">
### Leaflet 1.0, Chrome 49

![retina 1 0 chrome](https://cloud.githubusercontent.com/assets/1542531/14401796/4c0195e6-fdec-11e5-9350-f0d284769157.png)
### Leaflet 1.0, Firefox 47

<img width="1649" alt="retina 1 0 firefox" src="https://cloud.githubusercontent.com/assets/1542531/14401797/503f4ab8-fdec-11e5-8685-b42a455a3a1d.png">
## Non-Retina
### Leaflet 0.7, Chrome 49

![nonretina 0 7 chrome](https://cloud.githubusercontent.com/assets/1542531/14401772/67f81d34-fdeb-11e5-9d85-c1de67f76746.png)
### Leaflet 0.7, Firefox 47

![nonretina 0 7 firefox](https://cloud.githubusercontent.com/assets/1542531/14401774/734a0a08-fdeb-11e5-8327-2ebaf538f65a.png)
### Leaflet 1.0, Chrome 49

![nonretina 1 0 chrome](https://cloud.githubusercontent.com/assets/1542531/14401777/80f818ca-fdeb-11e5-8b87-f27310a8762e.png)
### Leaflet 1.0, Firefox 47

![nonretina 1 0 firefox](https://cloud.githubusercontent.com/assets/1542531/14401778/88080fe4-fdeb-11e5-9744-c71d539f83ad.png)
