### PR TITLE
Add support for heatmap.js layer

### DIFF
--- a/leaflet-image.js
+++ b/leaflet-image.js
@@ -36,16 +36,19 @@ module.exports = function leafletImage(map, callback) {
         layerQueue.defer(handlePathRoot, map._pathRoot);
     } else if (map._panes) {
         var firstCanvas = map._panes.overlayPane.getElementsByTagName('canvas').item(0);
+        var canvases = map._panes.overlayPane.getElementsByTagName('canvas');
         if (firstCanvas) {
-            if (firstCanvas.classList.contains("heatmap-canvas")) {
+            if (!firstCanvas.classList.contains("heatmap-canvas")) {
+                layerQueue.defer(handlePathRoot, firstCanvas);
+            }
+        }
+        for (var i = 0; i < canvases.length; i++) {
+            if (canvases.item(i).classList.contains("heatmap-canvas")) {
                 map.eachLayer(function(layer) {
                     if (layer._heatmap) {
                         layerQueue.defer(handleHeatMap, layer);
                     }
                 });
-                
-            } else {
-                layerQueue.defer(handlePathRoot, firstCanvas);
             }
         }
     }


### PR DESCRIPTION
This allows users to export their map, in addition to their [Heatmap.js](https://www.patrick-wied.at/static/heatmapjs/?utm_source=gh) data (using the [leaflet-heatmap.js plugin](https://github.com/pa7/heatmap.js/tree/develop/plugins)) as a single image/canvas/whatever you want to call it.

I personally needed this and I was hoping I could find a solution but instead i wrote my own. (whoops)

Heatmap.js (using the leaflet plugin) uses its own canvas for rendering. if we allow leaflet-image to apply its usual logic behind canvas layers, the output is distorted. instead, i have it draw the heatmap's own exportable dataURL. I'm hoping that the way i wrote this is compatible with environments without heatmap.js.
